### PR TITLE
Documentation branden

### DIFF
--- a/Visualize.m2
+++ b/Visualize.m2
@@ -831,11 +831,11 @@ document {
      Headline => "creates an interactive object in a modern browser",
      
      PARA "Given an open port, this method will create an interactive visualization of a variety of objects 
-     in a modern browser. While viewing the object, the user has the ability to manipulate and 
-     run various tests. Once finished, the user can export the finished result back to the 
+     in a modern browser. While viewing the object, the user has the ability to manipulate the 
+     object, and run various tests. Once finished, the user can export the finished result back to the 
      Macaulay2 session.",
                
-     PARA "The workflow for this package is as follows",
+     PARA "The workflow for this package is as follows:",
      
      UL{ "1. Load or install the package."},
      
@@ -852,17 +852,25 @@ document {
      
      UL{"6. Continue manipulating the object and repeat steps 3-5 as necessary."},
      
-     UL{{"7. When finished, close the port with ", TT "closePort()", " or restart Macaulay2"}},
+     UL{{"7. When finished, close the port with ", TT "closePort()", " or restart Macaulay2."}},
      
      }
 
 
 
 document {
-     Key => (visualize,Graph),
-     Headline => "A package to help visualize algebraic objects in the browser using javascript",
+     Key => {(visualize,Graph),[visualize, Verbose], [visualize, VisPath], [visualize, VisTemplate], [visualize, Warning]},
+     Headline => "visualizes a graph in a modern browser",
+     Usage => " H = visualize G",
+     Inputs => {
+	 "G" => Graph => " a graph",
+	 Verbose => Boolean => " prints server communication in the M2 buffer",
+	 VisPath => String => " a path where the visualization will be created and saved",
+	 VisTemplate => String => " a path to a user created/modified template",
+	 Warning => Boolean => " gives a warning if files will be overwritten when using VisPath",
+	 
      
-     PARA "Using JavaScript, this package creates interactive visualizations of a variety of objects 
+     PARA "Using JavaScript, this method creates interactive visualizations of a variety of objects 
      in a modern browser. While viewing the object, the user has the ability to manipulate and 
      run various tests. Once finished, the user can export the finished result back to the 
      Macaulay2 session.",

--- a/Visualize.m2
+++ b/Visualize.m2
@@ -971,6 +971,168 @@ document {
 
 
 document {
+     Key => [(visualize,Poset),FixExtremeElements],
+     Headline => "an option that brett created",
+     
+     PARA "Using JavaScript, this package creates interactive visualizations of a variety of objects 
+     in a modern browser. While viewing the object, the user has the ability to manipulate and 
+     run various tests. Once finished, the user can export the finished result back to the 
+     Macaulay2 session."
+     }
+ 
+document {
+     Key => [(visualize,Digraph),VisPath],
+     Headline => "an option that brett created",
+     
+     PARA "Using JavaScript, this package creates interactive visualizations of a variety of objects 
+     in a modern browser. While viewing the object, the user has the ability to manipulate and 
+     run various tests. Once finished, the user can export the finished result back to the 
+     Macaulay2 session."
+     }
+
+document {
+     Key => [(visualize,Graph),VisPath],
+     Headline => "an option that brett created",
+     
+     PARA "Using JavaScript, this package creates interactive visualizations of a variety of objects 
+     in a modern browser. While viewing the object, the user has the ability to manipulate and 
+     run various tests. Once finished, the user can export the finished result back to the 
+     Macaulay2 session."
+     }
+
+document {
+     Key => [(visualize,Ideal),VisPath],
+     Headline => "an option that brett created",
+     
+     PARA "Using JavaScript, this package creates interactive visualizations of a variety of objects 
+     in a modern browser. While viewing the object, the user has the ability to manipulate and 
+     run various tests. Once finished, the user can export the finished result back to the 
+     Macaulay2 session."
+     }
+
+document {
+     Key => [(visualize,Poset),VisPath],
+     Headline => "an option that brett created",
+     
+     PARA "Using JavaScript, this package creates interactive visualizations of a variety of objects 
+     in a modern browser. While viewing the object, the user has the ability to manipulate and 
+     run various tests. Once finished, the user can export the finished result back to the 
+     Macaulay2 session."
+     }
+
+document {
+     Key => [(visualize,SimplicialComplex),VisPath],
+     Headline => "an option that brett created",
+     
+     PARA "Using JavaScript, this package creates interactive visualizations of a variety of objects 
+     in a modern browser. While viewing the object, the user has the ability to manipulate and 
+     run various tests. Once finished, the user can export the finished result back to the 
+     Macaulay2 session."
+     }
+
+document {
+     Key => [(visualize,Digraph),VisTemplate],
+     Headline => "an option that brett created",
+     
+     PARA "Using JavaScript, this package creates interactive visualizations of a variety of objects 
+     in a modern browser. While viewing the object, the user has the ability to manipulate and 
+     run various tests. Once finished, the user can export the finished result back to the 
+     Macaulay2 session."
+     }
+
+document {
+     Key => [(visualize,Graph),VisTemplate],
+     Headline => "an option that brett created",
+     
+     PARA "Using JavaScript, this package creates interactive visualizations of a variety of objects 
+     in a modern browser. While viewing the object, the user has the ability to manipulate and 
+     run various tests. Once finished, the user can export the finished result back to the 
+     Macaulay2 session."
+     }
+
+document {
+     Key => [(visualize,Ideal),VisTemplate],
+     Headline => "an option that brett created",
+     
+     PARA "Using JavaScript, this package creates interactive visualizations of a variety of objects 
+     in a modern browser. While viewing the object, the user has the ability to manipulate and 
+     run various tests. Once finished, the user can export the finished result back to the 
+     Macaulay2 session."
+     }
+
+document {
+     Key => [(visualize,Poset),VisTemplate],
+     Headline => "an option that brett created",
+     
+     PARA "Using JavaScript, this package creates interactive visualizations of a variety of objects 
+     in a modern browser. While viewing the object, the user has the ability to manipulate and 
+     run various tests. Once finished, the user can export the finished result back to the 
+     Macaulay2 session."
+     }
+
+document {
+     Key => [(visualize,SimplicialComplex),VisTemplate],
+     Headline => "an option that brett created",
+     
+     PARA "Using JavaScript, this package creates interactive visualizations of a variety of objects 
+     in a modern browser. While viewing the object, the user has the ability to manipulate and 
+     run various tests. Once finished, the user can export the finished result back to the 
+     Macaulay2 session."
+     }
+
+document {
+     Key => [(visualize,Digraph),Warning],
+     Headline => "an option that brett created",
+     
+     PARA "Using JavaScript, this package creates interactive visualizations of a variety of objects 
+     in a modern browser. While viewing the object, the user has the ability to manipulate and 
+     run various tests. Once finished, the user can export the finished result back to the 
+     Macaulay2 session."
+     }
+
+document {
+     Key => [(visualize,Graph),Warning],
+     Headline => "an option that brett created",
+     
+     PARA "Using JavaScript, this package creates interactive visualizations of a variety of objects 
+     in a modern browser. While viewing the object, the user has the ability to manipulate and 
+     run various tests. Once finished, the user can export the finished result back to the 
+     Macaulay2 session."
+     }
+ 
+document {
+     Key => [(visualize,Ideal),Warning],
+     Headline => "an option that brett created",
+     
+     PARA "Using JavaScript, this package creates interactive visualizations of a variety of objects 
+     in a modern browser. While viewing the object, the user has the ability to manipulate and 
+     run various tests. Once finished, the user can export the finished result back to the 
+     Macaulay2 session."
+     }
+
+document {
+     Key => [(visualize,Poset),Warning],
+     Headline => "an option that brett created",
+     
+     PARA "Using JavaScript, this package creates interactive visualizations of a variety of objects 
+     in a modern browser. While viewing the object, the user has the ability to manipulate and 
+     run various tests. Once finished, the user can export the finished result back to the 
+     Macaulay2 session."
+     }
+
+document {
+     Key => [(visualize,SimplicialComplex),Warning],
+     Headline => "an option that brett created",
+     
+     PARA "Using JavaScript, this package creates interactive visualizations of a variety of objects 
+     in a modern browser. While viewing the object, the user has the ability to manipulate and 
+     run various tests. Once finished, the user can export the finished result back to the 
+     Macaulay2 session."
+     }
+
+
+
+document {
      Key => (visualize,Ideal),
      Headline => "A package to help visualize algebraic objects in the browser using javascript",
      
@@ -1011,8 +1173,8 @@ document {
      }
 
 document {
-     Key => openPort,
-     Headline => "A package to help visualize algebraic objects in the browser using javascript",
+     Key => {openPort,(openPort,String)},
+     Headline => "opens a port",
      
      PARA "Using JavaScript, this package creates interactive visualizations of a variety of objects 
      in a modern browser. While viewing the object, the user has the ability to manipulate and 
@@ -1022,8 +1184,8 @@ document {
 
 
 document {
-     Key => closePort,
-     Headline => "A package to help visualize algebraic objects in the browser using javascript",
+     Key => {closePort, (closePort)},
+     Headline => "closes and open port",
      
      PARA "Using JavaScript, this package creates interactive visualizations of a variety of objects 
      in a modern browser. While viewing the object, the user has the ability to manipulate and 

--- a/Visualize.m2
+++ b/Visualize.m2
@@ -859,15 +859,16 @@ document {
 
 
 document {
-     Key => {(visualize,Graph),[visualize, Verbose], [visualize, VisPath], [visualize, VisTemplate], [visualize, Warning]},
+     Key => {(visualize,Graph), [(visualize,Graph), VisPath], [(visualize,Graph), VisTemplate], [(visualize,Graph), Warning]},
      Headline => "visualizes a graph in a modern browser",
      Usage => " H = visualize G",
      Inputs => {
 	 "G" => Graph => " a graph",
-	 Verbose => Boolean => " prints server communication in the M2 buffer",
+--	 Verbose => Boolean => " prints server communication in the M2 buffer",
 	 VisPath => String => " a path where the visualization will be created and saved",
 	 VisTemplate => String => " a path to a user created/modified template",
-	 Warning => Boolean => " gives a warning if files will be overwritten when using VisPath",
+	 Warning => Boolean => " gives a warning if files will be overwritten when using VisPath"
+	 },
 	 
      
      PARA "Using JavaScript, this method creates interactive visualizations of a variety of objects 

--- a/Visualize.m2
+++ b/Visualize.m2
@@ -861,17 +861,15 @@ document {
 
 
 document {
-     Key => {(visualize,Graph), [(visualize,Graph), VisPath], [(visualize,Graph), VisTemplate], [(visualize,Graph), Warning]},
+     Key => (visualize,Graph),
      Headline => "visualizes a graph in a modern browser",
      Usage => " H = visualize G",
      Inputs => {
 	 "G" => Graph => " a graph",
-	 },
-     Options => {
-	 Verbose => Boolean => " prints server communication in the M2 buffer",
-	 VisPath => String => " a path where the visualization will be created and saved",
-	 VisTemplate => String => " a path to a user created/modified template",
-	 Warning => Boolean => " gives a warning if files will be overwritten when using VisPath"
+--	 Verbose => Boolean => " prints server communication in the M2 buffer",
+--	 VisPath => String => " a path where the visualization will be created and saved",
+--	 VisTemplate => String => " a path to a user created/modified template",
+--	 Warning => Boolean => " gives a warning if files will be overwritten when using VisPath"
 	 },
 	 
      

--- a/Visualize.m2
+++ b/Visualize.m2
@@ -241,12 +241,12 @@ relHeightFunction(Poset) := P -> (
 --
 visualize = method(Options => true)
 
-visualize(Ideal) := {VisPath => defaultPath, VisTemplate => currentDirectory() |"Visualize/templates/visIdeal/visIdea", Warning => true} >> opts -> J -> (
+visualize(Ideal) :=  {VisPath => defaultPath, Warning => true, VisTemplate => currentDirectory() |"Visualize/templates/visIdeal/visIdeal"} >> opts -> J -> (
     local R; local arrayList; local arrayString; local numVar; local visTemp;
     local varList;
     -- local A;
     
-    opts.VisTemplate = opts.VisTemplate | "Visualize/templates/visIdeal/visIdeal";
+    --opts.VisTemplate = opts.VisTemplate | "Visualize/templates/visIdeal/visIdeal";
         
     R = ring J;
     numVar = rank source vars R;
@@ -861,15 +861,17 @@ document {
 
 
 document {
-     Key => {(visualize,Graph)},-- [(visualize,Graph), VisPath], [(visualize,Graph), VisTemplate], [(visualize,Graph), Warning]},
+     Key => {(visualize,Graph), [(visualize,Graph), VisPath], [(visualize,Graph), VisTemplate], [(visualize,Graph), Warning]},
      Headline => "visualizes a graph in a modern browser",
      Usage => " H = visualize G",
      Inputs => {
 	 "G" => Graph => " a graph",
---	 Verbose => Boolean => " prints server communication in the M2 buffer",
---	 VisPath => String => " a path where the visualization will be created and saved",
---	 VisTemplate => String => " a path to a user created/modified template",
---	 Warning => Boolean => " gives a warning if files will be overwritten when using VisPath"
+	 },
+     Options => {
+	 Verbose => Boolean => " prints server communication in the M2 buffer",
+	 VisPath => String => " a path where the visualization will be created and saved",
+	 VisTemplate => String => " a path to a user created/modified template",
+	 Warning => Boolean => " gives a warning if files will be overwritten when using VisPath"
 	 },
 	 
      
@@ -1171,7 +1173,7 @@ I = ideal"a2,ab,b2c,c5,b4"
 visualize I
 visualize( I, VisPath => "/Users/bstone/Desktop/Test/", Warning => false)
 visualize( I, VisPath => "/Users/bstone/Desktop/Test/")
-
+y
 
 S = QQ[x,y]
 I = ideal"x4,xy3,y5"

--- a/Visualize.m2
+++ b/Visualize.m2
@@ -241,11 +241,13 @@ relHeightFunction(Poset) := P -> (
 --
 visualize = method(Options => true)
 
-visualize(Ideal) := {VisPath => defaultPath, VisTemplate => currentDirectory() |"Visualize/templates/visIdeal/visIdeal", Warning => true} >> opts -> J -> (
+visualize(Ideal) := {VisPath => defaultPath, VisTemplate => currentDirectory() |"Visualize/templates/visIdeal/visIdea", Warning => true} >> opts -> J -> (
     local R; local arrayList; local arrayString; local numVar; local visTemp;
     local varList;
     -- local A;
     
+    opts.VisTemplate = opts.VisTemplate | "Visualize/templates/visIdeal/visIdeal";
+        
     R = ring J;
     numVar = rank source vars R;
     varList = flatten entries vars R;
@@ -859,15 +861,15 @@ document {
 
 
 document {
-     Key => {(visualize,Graph), [(visualize,Graph), VisPath], [(visualize,Graph), VisTemplate], [(visualize,Graph), Warning]},
+     Key => {(visualize,Graph)},-- [(visualize,Graph), VisPath], [(visualize,Graph), VisTemplate], [(visualize,Graph), Warning]},
      Headline => "visualizes a graph in a modern browser",
      Usage => " H = visualize G",
      Inputs => {
 	 "G" => Graph => " a graph",
 --	 Verbose => Boolean => " prints server communication in the M2 buffer",
-	 VisPath => String => " a path where the visualization will be created and saved",
-	 VisTemplate => String => " a path to a user created/modified template",
-	 Warning => Boolean => " gives a warning if files will be overwritten when using VisPath"
+--	 VisPath => String => " a path where the visualization will be created and saved",
+--	 VisTemplate => String => " a path to a user created/modified template",
+--	 Warning => Boolean => " gives a warning if files will be overwritten when using VisPath"
 	 },
 	 
      

--- a/Visualize.m2
+++ b/Visualize.m2
@@ -241,12 +241,9 @@ relHeightFunction(Poset) := P -> (
 --
 visualize = method(Options => true)
 
-visualize(Ideal) :=  {VisPath => defaultPath, Warning => true, VisTemplate => currentDirectory() |"Visualize/templates/visIdeal/visIdeal"} >> opts -> J -> (
+visualize(Ideal) := {VisPath => defaultPath, Warning => true, VisTemplate => currentDirectory() |"Visualize/templates/visIdeal/visIdeal"} >> opts -> J -> (
     local R; local arrayList; local arrayString; local numVar; local visTemp;
     local varList;
-    -- local A;
-    
-    --opts.VisTemplate = opts.VisTemplate | "Visualize/templates/visIdeal/visIdeal";
         
     R = ring J;
     numVar = rank source vars R;
@@ -267,7 +264,7 @@ visualize(Ideal) :=  {VisPath => defaultPath, Warning => true, VisTemplate => cu
 	    );
 	
 	arrayList = apply( flatten entries gens J, m -> flatten exponents m);	
-	arrayList = toArray arrayList;
+arrayList = toArray arrayList;
 	arrayString = toString arrayList;
 	
 	searchReplace("visArray",arrayString, visTemp);
@@ -930,6 +927,48 @@ document {
 --     Caveat => {"When in the browser, and editing is on, you can move the nodes of a graph by pressing SHIFT and moving them."}
      
      }
+ 
+ document {
+     Key => VisPath,
+     Headline => "an option to define a path save visualizations",
+     
+     PARA "Using JavaScript, this package creates interactive visualizations of a variety of objects 
+     in a modern browser. While viewing the object, the user has the ability to manipulate and 
+     run various tests. Once finished, the user can export the finished result back to the 
+     Macaulay2 session."
+     }
+
+document {
+     Key => VisTemplate,
+     Headline => "an option to define a path to a user defined template",
+     
+     PARA "Using JavaScript, this package creates interactive visualizations of a variety of objects 
+     in a modern browser. While viewing the object, the user has the ability to manipulate and 
+     run various tests. Once finished, the user can export the finished result back to the 
+     Macaulay2 session."
+     }
+ 
+document {
+     Key => Warning,
+     Headline => "an option to squelch warnings",
+     
+     PARA "Using JavaScript, this package creates interactive visualizations of a variety of objects 
+     in a modern browser. While viewing the object, the user has the ability to manipulate and 
+     run various tests. Once finished, the user can export the finished result back to the 
+     Macaulay2 session."
+     }
+
+document {
+     Key => FixExtremeElements,
+     Headline => "an option that Brett made",
+     
+     PARA "Using JavaScript, this package creates interactive visualizations of a variety of objects 
+     in a modern browser. While viewing the object, the user has the ability to manipulate and 
+     run various tests. Once finished, the user can export the finished result back to the 
+     Macaulay2 session."
+     }
+
+
 
 document {
      Key => (visualize,Ideal),

--- a/Visualize.m2
+++ b/Visualize.m2
@@ -960,7 +960,7 @@ document {
 
 document {
      Key => FixExtremeElements,
-     Headline => "an option that Brett made",
+     Headline => "an option that brett created",
      
      PARA "Using JavaScript, this package creates interactive visualizations of a variety of objects 
      in a modern browser. While viewing the object, the user has the ability to manipulate and 


### PR DESCRIPTION
All current methods now have their documentation template. I still get a warning for `closePort()` but I think that is because it does not take an input. 