### PR TITLE
Fixed visPoset

### DIFF
--- a/Visualize/js/visDigraph2d.js
+++ b/Visualize/js/visDigraph2d.js
@@ -505,7 +505,7 @@ function restart() {
         }
       }
       
-      if(name != null) {
+      if(name != "null") {
         d.name = name;
         d3.select(this.parentNode).select("text").text(function(d) {return d.name});          
       }

--- a/Visualize/js/visGraph2d.js
+++ b/Visualize/js/visGraph2d.js
@@ -452,7 +452,7 @@ function restart() {
         }
       }
       
-      if(name != null) {
+      if(name != "null") {
         d.name = name;
         d3.select(this.parentNode).select("text").text(function(d) {return d.name});          
       }

--- a/Visualize/templates/visPoset/visPoset-template.html
+++ b/Visualize/templates/visPoset/visPoset-template.html
@@ -131,26 +131,12 @@
       curEdit = false;
       curHighlight = false;
       menuOpen = false;
-  /*    dataNodes = [
-		{"name": "1", "group":0},
-		{"name": "2", "group":1},
-		{"name": "3", "group":1},
-		{"name": "4", "group":2},
-		{"name": "5", "group":1},
-		{"name": "6", "group":2}
-	   ];*/
       dataLabels = visLabels;
       //dataNodes = visNodes;
-    /*  dataLinks = [
-		{"source":0,"target":1,"value":1},
-		{"source":0,"target":2,"value":2},
-		{"source":0,"target":4,"value":3},
-		{"source":1,"target":3,"value":1},
-		{"source":2,"target":5,"value":2},
-        {"source":4,"target":3,"value":1}
-	   ];*/
-      dataLinks = visRelations;
+      //dataLinks = visRelations;
       dataRelMatrix = visRelMatrix;
+      dataCovRel = null;
+      dataGroupList = null;
       portData = visPort; // initializes port from user
       fixExtremalNodes = visExtremeElts;
       forceOn = false;
@@ -218,7 +204,7 @@
           document.getElementById("endSession").style.color = 'white';
           document.getElementById("endSession").style.backgroundColor = 'red';
           document.getElementById("endSession").innerHTML = "Session terminated";
-          makeCorsRequest('POST','http://localhost:'+portData+'/end/',poset2M2Constructor(nodes,links));
+          makeCorsRequest('POST','http://localhost:'+portData+'/end/',poset2M2Constructor(dataLabels,dataRelMatrix));
           activeSession = !activeSession;
         } else {
           return;


### PR DESCRIPTION
M2 now passes the labels of the elements and the relation matrix for the poset to the html template.  There are now methods to convert this data to the nodes and links arrays to use in the force layout.  We can now try to start adding poset editing and various poset tests from M2.

There were also very minor edits to visGraph and visDigraph modifying how they handled the user cancelling the prompt to rename a node.