### PR TITLE
Editing 2-dimensional faces in simplicial complexes

### DIFF
--- a/Visualize/templates/visSimplicialComplex/visSimplicialComplex2d-template.html
+++ b/Visualize/templates/visSimplicialComplex/visSimplicialComplex2d-template.html
@@ -86,7 +86,7 @@
       path.link {
         fill: none;
         stroke: #999;
-        stroke-width: 2px;
+        stroke-width: 3px;
         cursor: default;
         stroke-opacity: .6;
       }
@@ -142,6 +142,10 @@
         
       polygon.face {
         opacity: .4;
+      }
+        
+      #canvasElement2d:not(.active):not(.shift) polygon.face {
+        cursor: pointer;
       }
         
       polygon.face.highlighted {


### PR DESCRIPTION
Added the ability to create and delete 2-dimensional faces in simplicial complexes.

- To create a 2-dimensional face, enable editing, hold the 'f' key (for **f**ace) and click any three different nodes in succession.  If the face already exists, nothing happens.  If any 1-dimensional subface of the new 2-dimensional face does not already belong to the simplicial complex, it is automatically added.
- To delete a 2-dimensional face, enable editing, click on any face (it will be surrounded by a dotted line, although I am very open to changing the appearance of this) and press delete or backspace.

Any time a node is deleted, any 1- or 2-dimensional face involving that node is also automatically deleted.  Similarly, any time a 1-dimensional face is deleted, every 2-dimensional face involving that edge is also automatically deleted.